### PR TITLE
Support broadcast for user-defined functions !! 😄 💯 

### DIFF
--- a/src/JITrench.jl
+++ b/src/JITrench.jl
@@ -61,6 +61,7 @@ include("core/operators.jl")
 include("core/propagation.jl")
 include("core/math_functions.jl")
 
+
 include("arr/reshape.jl")
 include("arr/flatten.jl")
 include("arr/transpose.jl")
@@ -68,6 +69,7 @@ include("arr/sum.jl")
 include("arr/sum_to.jl")
 include("arr/broadcast_to.jl")
 include("arr/broadcast.jl")
+include("arr/broadcast_wrapper.jl")
 include("arr/matmul.jl")
 include("arr/getindex.jl")
 
@@ -91,3 +93,5 @@ include("nn/optimizer/sgd.jl")
 export Variable, DiffableFunction, backward!, parameters, cleargrad!, flatten, matmul, sum_to, sigmoid, mean_squared_error, linear, Model, Layer, SGD, @diff!
 
 end
+
+

--- a/src/arr/broadcast_wrapper.jl
+++ b/src/arr/broadcast_wrapper.jl
@@ -1,0 +1,29 @@
+mutable struct BroadcastWrapper{F} <: DiffableFunction
+    func :: F
+end
+
+Base.broadcasted(f, args::Variable...) = BroadcastWrapper(f)(args...)
+
+function backward(f::BroadcastWrapper, gy)
+    f_gradfield = f.grad_field
+end
+
+function req_broadcast!(vars)
+    for var in vars
+        var.req_broadcast = true
+    end
+end
+
+function fin_broadcast!(vars)
+    for var in vars
+        var.req_broadcast = false
+    end
+end
+
+function (f::BroadcastWrapper)(vars...) 
+    req_broadcast!(vars)
+    true_func = f.func
+    y = f.func(vars...)
+    fin_broadcast!(vars)
+    return y
+end

--- a/src/core/math_functions.jl
+++ b/src/core/math_functions.jl
@@ -105,6 +105,7 @@ for (func, jt_func) in math_functions
     @eval $func(x::Variable) = $jt_func(GradField())(x)
     @eval is_support(::typeof($func)) = true
     @eval is_support_broadcast(::typeof($func)) = true
-    @eval get_jt_struct(::typeof($func)) = $jt_func
+    @eval base_to_jt(::typeof($func)) = $jt_func
+    @eval jt_to_base(::$(jt_func)) = $func
 end
 

--- a/src/core/operators.jl
+++ b/src/core/operators.jl
@@ -109,15 +109,14 @@ const normal_operators = Dict(
 Base.:-(x::Variable) = Neg(GradField())(x)
 Base.:^(x::Variable, c) = Pow(GradField(), c)(x)
 is_support(::typeof(^)) = true
-get_jt_struct(::typeof(^)) = Pow
+base_to_jt(::typeof(^)) = Pow
 
 for (op, jt_func) in normal_operators
     @eval is_support(::typeof(Base.$op)) = true
     @eval is_support_broadcast(::typeof(Base.$op)) = true
-    @eval get_jt_struct(::typeof(Base.$op)) = $jt_func
+    @eval base_to_jt(::typeof(Base.$op)) = $jt_func
+    @eval jt_to_base(::$(jt_func)) = Base.$op
     @eval Base.$op(x1::Variable, x2::Real) = Base.$op(promote(x1, x2)...)
     @eval Base.$op(x1::Real, x2::Variable) = Base.$op(promote(x1, x2)...)
     @eval Base.$op(x1::Variable, x2::Variable) = $jt_func(GradField())(x1, x2)
 end
-
-

--- a/src/core/operators.jl
+++ b/src/core/operators.jl
@@ -107,9 +107,11 @@ const normal_operators = Dict(
 
 
 Base.:-(x::Variable) = Neg(GradField())(x)
+jt_to_base(::Neg) = -
 Base.:^(x::Variable, c) = Pow(GradField(), c)(x)
 is_support(::typeof(^)) = true
 base_to_jt(::typeof(^)) = Pow
+jt_to_base(::Pow) = ^
 
 for (op, jt_func) in normal_operators
     @eval is_support(::typeof(Base.$op)) = true

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -27,8 +27,9 @@ mutable struct Variable{T} <: TrenchObject
     grad::Union{Nothing, Variable}
     generation::Int
     name::Union{Nothing,String}
-    function Variable(values::T; creator=nothing, grad=nothing, generation=0, name=nothing) where {T <: Union{<:Real,AbstractArray{<:Real}}}
-        new{T}(values, creator, grad, generation, name)
+    req_broadcast :: Bool
+    function Variable(values::T; creator=nothing, grad=nothing, generation=0, name=nothing, req_broadcast=false) where {T <: Union{<:Real,AbstractArray{<:Real}}}
+        new{T}(values, creator, grad, generation, name, req_broadcast)
     end
 end
 

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -45,10 +45,7 @@ Base.size(x::Variable) = size(x.values)
 function get_output_str(var::Variable)
     output = ""
     output *= "name: $(var.name) \n"
-    io = IOBuffer()
-    show(IOContext(io, :limit => true), "text/plain", var.values);
-    s = String(take!(io))
-    output *= "values: $(s)\n"
+    output *= "values: $(var.values)\n"
     if (var.grad !== nothing) 
         output *= "grad: $(var.grad)\n"
     end

--- a/src/nn/funcitons/activation/sigmoid.jl
+++ b/src/nn/funcitons/activation/sigmoid.jl
@@ -20,11 +20,8 @@ function backward(f::Sigmoid, gy::Variable{T}) where {T <: AbstractArray}
 end
 
 sigmoid(x::Variable) = Sigmoid(GradField())(x)
-
-Base.broadcasted(::typeof(sigmoid), x::Variable)  = Broadcasting(_sigmoid, Sigmoid(GradField()))(x)
-
-
-
+base_to_jt(::typeof(sigmoid)) = Sigmoid
+jt_to_base(::Sigmoid) = sigmoid
 
 
 

--- a/src/nn/funcitons/activation/sigmoid.jl
+++ b/src/nn/funcitons/activation/sigmoid.jl
@@ -1,4 +1,4 @@
-mutable struct Sigmoid <: DiffableFunction
+mutable struct Sigmoid <: SingleReturnFunction
     grad_field :: GradField
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ test_files = Dict(
     "arr" => [
         "broadcast_to.jl",
         "broadcast.jl",
-        "flatten.jl"
+        "flatten.jl",
+        "broadcast_wrapper.jl"
     ]
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,8 @@ test_files = Dict(
     ],
     "arr" => [
         "broadcast_to.jl",
-        "broadcast.jl"
+        "broadcast.jl",
+        "flatten.jl"
     ]
 )
 
@@ -22,144 +23,8 @@ for (dir, files) in test_files
     @testset "$dir" begin
         for file in files
             @testset "$file" begin
-                # println("test: ", "test/src/" * dir * "/" * file)
                 include("src/" * dir * "/" * file)
             end
         end
     end
 end
-
-
-
-# using Random
-# using StatsBase
-# using Printf
-# using JITrench
-
-# include("test_utils.jl")
-
-# operators = [+, -, /, *]
-
-# function test_all(
-#     N_TEST_COUNT = 100
-# )
-# @testset "OperatorTest" begin
-#     @testset "ForwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for op in operators
-#                 x1 = rand()
-#                 x2 = rand()
-#                 @test isAbout(op(Variable(x1), Variable(x2)).values, op(x1, x2), )
-#             end
-#         end
-#     end
-#     @testset "backwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for op in operators[1:end-1]
-#                 x1 = rand()
-#                 x2 = rand()
-#                 @test isAbout(backward_diff(op, [x1, x2]), numerical_diff(op, [x1, x2]))
-#             end
-#         end
-#     end
-# end
-
-# funcitons = [
-#     sin,
-#     cos,
-#     tan,
-#     log,
-#     exp
-# ]
-
-# @testset "MathFuncTest" begin
-#     @testset "ForwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for op in funcitons
-#                 x = rand()
-#                 @test isAbout(op(x), op(Variable(x).values))
-#             end
-#         end
-#     end
-#     @testset "backwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for op in funcitons
-#                 x = rand()
-#                 @test isAbout(backward_diff(op, [x]), numerical_diff(op, [x]))
-#             end
-#         end
-#     end  
-# end
-
-# activations = Dict(
-#     JITrench._sigmoid => JITrench.sigmoid 
-# )
-
-# @testset "ActivationTest" begin
-#     @testset "ForwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for (func, jt_func) in activations
-#                 x = rand()
-#                 isAbout(func(x), jt_func(Variable(x)).values)
-#             end
-#         end
-#     end
-#     @testset "backwardTest" begin
-#         for i in 1:N_TEST_COUNT
-#             for (func, jt_func) in activations
-#                 x = rand()
-#                 @test isAbout(backward_diff(jt_func, [x]), numerical_diff(func, [x]))
-#             end
-#         end
-#     end  
-# end
-
-
-# @testset "ArrOperateTest" begin
-#     max_size = 120
-#     @testset "forward" begin
-#         @testset "reshape" begin
-#             for _ in 1:N_TEST_COUNT
-#                 in_shape, out_shape = generate_shape(rand(1:max_size))
-#                 x = rand(in_shape...)
-#                 y_arr = reshape(x, out_shape)
-#                 y_var = reshape(Variable(x), out_shape)
-#                 @test y_arr == y_var.values
-#             end
-#         end
-#         @testset "transpose" begin
-#             for _ in 1:N_TEST_COUNT
-#                 in_shape, out_shape = generate_shape(rand(1:max_size), max_dim=2)
-#                 x = rand(in_shape...)
-#                 y_arr = transpose(x)
-#                 y_var = transpose(Variable(x))
-#                 @test y_arr == y_var.values
-#             end
-#         end
-#     end 
-#     @testset "backward" begin
-#         @testset "reshape" begin
-#             for _ in 1:N_TEST_COUNT
-#                 in_shape, out_shape = generate_shape(rand(1:max_size))
-#                 x = Variable(rand(in_shape...))
-#                 y = reshape(x, out_shape)
-#                 backward!(y, retain_grad=true)
-#                 @test y.grad.values == ones(size(y.values))
-#                 @test x.grad.values == ones(size(x.values))
-#             end
-#         end
-#         @testset "transpose" begin
-#             for _ in 1:N_TEST_COUNT
-#                 in_shape, out_shape = generate_shape(rand(1:max_size), min_dim=2, max_dim=2)
-#                 x = Variable(rand(in_shape...))
-#                 y = JITrench.transpose(x)
-#                 backward!(y, retain_grad=true)
-#                 @test y.grad.values == ones(size(y.values))
-#                 @test x.grad.values == ones(size(x.values))
-#             end
-#         end
-#     end
-# end
-
-
-# end

--- a/test/src/arr/broadcast_to.jl
+++ b/test/src/arr/broadcast_to.jl
@@ -1,33 +1,39 @@
 using Test
 using JITrench
 
-x = Variable(1)
-
-y = JITrench.broadcast_to(x, (2, 2))
-
-@test y.values == [1 1; 1 1]
-@test y.creator isa JITrench.BroadcastTo
-@test y.creator.shape == (2, 2)
-@test y.creator.x_shape == () 
-
-backward!(y, retain_grad=true)
-
-@test size(y.grad) == size(y)
-@test size(x.grad) == size(x)
-@test y.grad.values == [1 1; 1 1]
-@test x.grad.values == 4
 
 
-x = Variable([1, 2])
+@testset "BroadCastToForwardTest" begin
 
-y = JITrench.broadcast_to(x, (2, 2))
+    x = Variable(1)
 
-@test y.values == [1 1; 2 2]
-@test y.creator isa JITrench.BroadcastTo
-@test y.creator.shape == (2, 2)
-@test y.creator.x_shape == (2, ) 
+    y = JITrench.broadcast_to(x, (2, 2))
 
-backward!(y, retain_grad=true)
+    @test y.values == [1 1; 1 1]
+    @test y.creator isa JITrench.BroadcastTo
+    @test y.creator.shape == (2, 2)
+    @test y.creator.x_shape == () 
 
-@test size(y.grad) == size(y)
-@test size(x.grad) == size(x)
+    backward!(y, retain_grad=true)
+
+    @test size(y.grad) == size(y)
+    @test size(x.grad) == size(x)
+    @test y.grad.values == [1 1; 1 1]
+    @test x.grad.values == 4
+
+
+    x = Variable([1, 2])
+
+    y = JITrench.broadcast_to(x, (2, 2))
+
+    @test y.values == [1 1; 2 2]
+    @test y.creator isa JITrench.BroadcastTo
+    @test y.creator.shape == (2, 2)
+    @test y.creator.x_shape == (2, ) 
+
+    backward!(y, retain_grad=true)
+
+    @test size(y.grad) == size(y)
+    @test size(x.grad) == size(x)
+
+end

--- a/test/src/arr/broadcast_wrapper.jl
+++ b/test/src/arr/broadcast_wrapper.jl
@@ -1,0 +1,18 @@
+@testset "UserDefinedFunctionBroadcastTest" begin
+    funcs = (
+        (x -> x + 1), 
+        (x -> 3x + 1), 
+        (x -> 3x^2 + 5x + 1), 
+        (x -> exp(x) - 10), 
+        (x -> -x), 
+        (x -> sin(x) + cos(sin(x)))
+    ) 
+    for f in funcs
+        x = rand(10)
+        y = f.(x)
+        x_var = Variable(x)
+        y_var = f.(x_var)
+        @test y == y_var.values
+        @test x_var.req_broadcast == false
+    end
+end

--- a/test/src/arr/flatten.jl
+++ b/test/src/arr/flatten.jl
@@ -1,0 +1,9 @@
+@testset "FlattenForwardTest" begin
+    n_testcase = 10
+    for i in 1:n_testcase
+        n_element = rand(1:120)
+        shape = randshape(n_element)
+        arr = rand(1:20, shape)
+        @test flatten(Variable(arr)).values == vcat(arr...)
+    end
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -52,7 +52,6 @@ function randshape(N::Int; min_dim=1, max_dim=10)
     if shape_length > length(facts)
         append!(facts, ones(Int, shape_length - length(facts)))
     end
-    # assign prod group
     assign = rand(1:shape_length, length(facts))
-    result = (i -> prod(getindex.(Ref(facts), findall(x -> x == i, assign)))).(1:shape_length)
+    return Tuple((i -> prod(getindex.(Ref(facts), findall(x -> x == i, assign)))).(1:shape_length))
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,22 +1,8 @@
-using Primes
-
-function randfact(N; min_len=1, max_len=10)
-    l = rand(min_len:max_len)
-    base_arr = factor(Array, N)
-    ind = rand(1:l, length(base_arr))
-    return prod.(getindex.(Ref(base_arr), (i -> ind .== i).(1:l)))
-end
-
-
-function generate_shape(n_elemtnt; min_dim=1, max_dim=5)
-    return Tuple(randfact(n_elemtnt, max_len=max_dim)), Tuple(randfact(n_elemtnt, min_len=min_dim, max_len=max_dim))
-end
-
+using Random
 
 function numerical_diff(f::Function, x::Real; e=1e-7)
     return (f(x + e) - f(x - e)) / 2e
 end
-
 
 function numerical_diff(f::Function, xs::AbstractArray; e=1e-7)
     grads = zeros(length(xs)) 
@@ -60,8 +46,13 @@ function ≃(X::AbstractArray, Y::AbstractArray; e=1e-4)
 end
 
 
-function random_arr(;min_dim=1, max_dim=4, min_r=1, max_r=10, collection=Float64)
-    dim = rand(min_dim:max_dim)
-    shape = Tuple(rand(min_r:max_r, dim))
-    return rand(collection, shape)
+function randshape(N::Int; min_dim=1, max_dim=10)
+    shape_length = rand(min_dim:max_dim) 
+    facts = factor(Array, N)
+    if shape_length > length(facts)
+        append!(facts, ones(Int, shape_length - length(facts)))
+    end
+    # assign prod group
+    assign = rand(1:shape_length, length(facts))
+    result = (i -> prod(getindex.(Ref(facts), findall(x -> x == i, assign)))).(1:shape_length)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,4 +1,5 @@
 using Random
+using Primes
 
 function numerical_diff(f::Function, x::Real; e=1e-7)
     return (f(x + e) - f(x - e)) / 2e


### PR DESCRIPTION
current:
```julia
julia> f(x) = 2x + 1
f (generic function with 1 method)

julia> x = Variable([1, 2, 3])
name: nothing
values: 3-element Vector{Int64}:
 1
 2
 3
creator: User-Defined(nothing)

julia> f.(x)
ERROR: MethodError: no method matching length(::Variable{Vector{Int64}})
Closest candidates are:
  length(::Union{Base.KeySet, Base.ValueIterator}) at abstractdict.jl:58
  length(::Union{LinearAlgebra.Adjoint{T, S}, LinearAlgebra.Transpose{T, S}} where {T, S}) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:195
  length(::Union{DataStructures.OrderedRobinDict, DataStructures.RobinDict}) at /Users/yuchi_ymgc/.julia/packages/DataStructures/ixwFs/src/ordered_robin_dict.jl:86
  ...
Stacktrace:
 [1] _similar_for(c::UnitRange{Int64}, #unused#::Type{Any}, itr::Variable{Vector{Int64}}, #unused#::Base.HasLength)
   @ Base ./array.jl:575
 [2] _collect(cont::UnitRange{Int64}, itr::Variable{Vector{Int64}}, #unused#::Base.HasEltype, isz::Base.HasLength)
   @ Base ./array.jl:608
 [3] collect(itr::Variable{Vector{Int64}})
   @ Base ./array.jl:602
 [4] broadcastable(x::Variable{Vector{Int64}})
   @ Base.Broadcast ./broadcast.jl:682
 [5] broadcasted(::Function, ::Variable{Vector{Int64}})
   @ Base.Broadcast ./broadcast.jl:1307
 [6] top-level scope
   @ REPL[3]:1
```

after this PR:
```julia
julia> f(x) = 2x + 1
f (generic function with 1 method)

julia> x = Variable([1, 2, 3])
name: nothing
values: [1, 2, 3]
creator: User-Defined(nothing)

julia> y = f.(x)
name: nothing
values: [3, 5, 7]
creator: JITrench.Broadcasting{typeof(+)}
```
Computational graph:
![graph](https://user-images.githubusercontent.com/53076594/165514245-a1f3b1cd-e590-4d6c-ad2e-161144b6c9a6.png)

To implement this future, we add a new field, `req_broadcast` to `Variable`.
After this PR, all arguments of  `DiffableFunction` are checked in this field, and when it is `true`, arguments become a target for broadcast.

This may slow down the computation.
Since there are only a limited number of function calls that need to be broadcast, good optimization should reduce the overhead of this check.