### PR TITLE
Better CUDA  Support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,12 @@ version = "0.1.0"
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 DataStructures = "0.18"

--- a/src/JITrench.jl
+++ b/src/JITrench.jl
@@ -11,6 +11,9 @@ include("core/autodiff/autodiff.jl")
 
 export AutoDiff, DiffableFunction, backward!, Scalar, AbstractTensor, Tensor, CuTensor
 
+Device = AutoDiff.Device
+GPU = AutoDiff.GPU
+CPU = AutoDiff.CPU
 
 include("core/functions.jl")
 

--- a/src/core/autodiff/propagation.jl
+++ b/src/core/autodiff/propagation.jl
@@ -534,9 +534,9 @@ function backward!(y::Scalar; retain_grad = false, create_graph = false)
     seen_set = Set{DiffableFunction}()
     if y.grad isa Nothing
         if create_graph
-            y.grad = ones_like(y)
+            y.grad = Scalar(1.0)
         else
-            y.grad = ones_like(y.values)
+            y.grad = 1.0
         end
     end
     DataStructures.enqueue!(que, y.creator, 1)

--- a/src/core/autodiff/propagation.jl
+++ b/src/core/autodiff/propagation.jl
@@ -1,4 +1,5 @@
 using DataStructures
+using GPUArraysCore
 
 using ..JITrench
 
@@ -37,7 +38,8 @@ function out_to_tensor(
     creator = nothing,
     grad = nothing,
     req_broadcast = false,
-)   return Tensor(
+)   
+    return Tensor(
         y,
         creator = creator,
         grad = grad,
@@ -47,13 +49,14 @@ function out_to_tensor(
 end
 
 function out_to_tensor(
-    y::CuArray,
-    generation::Int,
-    device_idx::Int;
+    y::GPUArraysCore.AbstractGPUArray,
+    generation::Int;
+    device_idx=0::Int,
     creator = nothing,
     grad = nothing,
     req_broadcast = false,
-) return CuTensor(
+) 
+    return CuTensor(
         y,
         creator = creator,
         grad = grad,

--- a/src/core/functions.jl
+++ b/src/core/functions.jl
@@ -1,6 +1,7 @@
 using .AutoDiff
 import .AutoDiff: forward, backward, call!
 import Base
+using GPUArraysCore
 
 struct Add <: BinaryOperator
     grad_field::GradField
@@ -102,6 +103,9 @@ Base.:+(::T, ::S) where {T <: CuTensor, S <: AbstractArray} =
 Base.:+(::S, ::T) where {T <: CuTensor, S <: AbstractArray} =
     NotSameDeviceError(same_accelerator = false, same_gpu_idx = false)
 
+Base.:+(x1::T, x2::S) where {T <: CuTensor, S <: GPUArraysCore.AbstractGPUArray} = call!(Add, x1, CuTensor(x2))
+Base.:+(x1::S, x2::T) where {T <: CuTensor, S <: GPUArraysCore.AbstractGPUArray} = call!(Add, CuTensor(x1), x2)
+
 Base.:+(x1::AbstractTensor, x2::Real) = call!(Add, x1, Scalar(x2))
 Base.:+(x1::Real, x2::AbstractArray) = call!(Add, Scalar(x1), x2)
 Base.:+(x1::AbstractArray, x2::Scalar) = call!(Add, Tensor(x1), x2)
@@ -152,8 +156,11 @@ Base.:-(::CuTensor, ::AbstractArray) =
 Base.:-(::S, ::T) where {T <: CuTensor, S <: AbstractArray} =
     NotSameDeviceError(same_accelerator = false, same_gpu_idx = false)
 
-Base.:-(x::Variable) = call!(Neg, x)
+Base.:-(x1::T, x2::S) where {T <: CuTensor, S <: GPUArraysCore.AbstractGPUArray} = call!(Sub, x1, CuTensor(x2))
+Base.:-(x1::S, x2::T) where {T <: CuTensor, S <: GPUArraysCore.AbstractGPUArray} = call!(Sub, CuTensor(x1), x2)
 
+
+Base.:-(x::Variable) = call!(Neg, x)
 
 Base.:-(x1::AbstractTensor, x2::Real) = call!(Sub, x1, Scalar(x2))
 Base.:-(x1::Real, x2::AbstractTensor) = call!(Sub, Scalar(x1), x2)
@@ -204,6 +211,11 @@ Base.:*(::CuTensor, ::AbstractArray) =
 Base.:*(::AbstractArray, ::CuTensor) =
     NotSameDeviceError(same_accelerator = false, same_gpu_idx = false)
 
+Base.:*(x1::CuTensor, x2::GPUArraysCore.AbstractGPUArray) = call!(Mul, x1, CuTensor(x2))
+Base.:*(x1::GPUArraysCore.AbstractGPUArray, x2::CuTensor) = call!(Mul, CuTensor(x1), x2)
+
+    
+
 Base.:/(x1::Scalar, x2::Scalar) = call!(Div, x1, x2)
 Base.:/(x1::Scalar, x2::Real) = call!(Div, x1, Scalar(x2))
 Base.:/(x1::Real, x2::Scalar) = call!(Div, Scalar(x1), x2)
@@ -213,10 +225,8 @@ Base.:/(x1::Tensor, x2::AbstractArray) = call!(Div, x1, Tensor(x2))
 Base.:/(x1::AbstractArray, x2::Tensor) = call!(Div, Tensor(x1), x2)
 
 Base.:/(x1::CuTensor, x2::CuTensor) = call!(Div, x1, x2)
-Base.:/(::CuTensor, ::AbstractArray) =
-    NotSameDeviceError(same_accelerator = false, same_gpu_idx = false)
-Base.:/(::AbstractArray, ::CuTensor) =
-    NotSameDeviceError(same_accelerator = false, same_gpu_idx = false)
+Base.:/(x1::CuTensor, x2::GPUArraysCore.AbstractGPUArray) = call!(Div, x1, x2)
+Base.:/(x1::GPUArraysCore.AbstractGPUArray, x2::CuTensor) = call!(Div, x1, x2)
 
 function Base.:/(x1::AbstractTensor, x2::AbstractTensor)
     if check_broadcastable(x1, x2)

--- a/src/nn/layer/compute.jl
+++ b/src/nn/layer/compute.jl
@@ -27,12 +27,12 @@ function (layer::Layer)(ctx::ComputeContext)
     return ctx
 end
 
-function apply(model::Function, x::AbstractTensor, param::Parameter)
+function apply(model::Function, x::T, param::Parameter) where T
     name_controller = DefaultDict{String, Int}(0)
     for key in keys(param)
         name_controller[key] = 0
     end
-    model(ComputeContext(x, param, name_controller))
+    model(ComputeContext{T}(x, param, name_controller))
 end
 
 function result(ctx::ComputeContext)

--- a/src/nn/layer/layer.jl
+++ b/src/nn/layer/layer.jl
@@ -1,7 +1,7 @@
 using ..JITrench 
 using DataStructures: OrderedDict, DefaultDict
 
-Parameter = OrderedDict{String, Dict{String, <: Tensor}}
+Parameter = OrderedDict{String, Dict{String, <: AbstractTensor}}
 
 abstract type Layer end
 


### PR DESCRIPTION
-  Export devices API 
-  Better multiple dispatch with`GPUArraysCore.AbstractGPUArray`
- `Initializer`, `Parameter` support for CuTensor
- `Linear` support for direct initialization with CuTensor
-  Support promote for `GPUArraysCore.AbstractGPUArray`
-  Force leaf nodes to only contain scalar gradients 
- Better implement for calculate gradient with CUDA in `MeanSquaredError`
- Generate `ComputeContext` for every calculation
- Add `GPUArraysCore` and `MLDatasets`